### PR TITLE
disable comments for "too old" episodes and enable spam reporting again

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -103,6 +103,10 @@ class Episode < ActiveRecord::Base
     self.seconds = min*60 + sec
   end
 
+  def old?
+    self.published_at <= 3.months.ago
+  end
+
   private
 
   def self.primitive_search_conditions(query)

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -31,8 +31,6 @@
       <%= link_to "Edit", edit_comment_path(comment) %> |
       <%= link_to "Destroy", comment, :confirm => 'Are you sure?', :method => :delete, :class => 'destroy' %> |
     <% end %>
-    <% if comment.user.nil? %>
-      <%= link_to "Report as Spam", spam_reports_path(:comment_id => comment), :method => :post, :class => 'spam_report' %>
-    <% end %>
+    <%= link_to "Report as Spam", spam_reports_path(:comment_id => comment), :method => :post, :class => 'spam_report' %>
   </div>
 <% end %>

--- a/app/views/episodes/show.html.erb
+++ b/app/views/episodes/show.html.erb
@@ -31,14 +31,16 @@
   </div>
 <% end %>
 
-<div class="content add_comment">
-  <% if current_user %>
-    <h3>Add your comment:</h3>
-    <p class="comment_profile">
-      Signed in as <strong><%= link_to current_user.name, current_user %></strong>.
-    </p>
-    <%= render :partial => 'comments/form' %>
-  <% else %>
-    <p>You must <%= link_to "sign in through GitHub", login_path(:return_to => request.url) %> to post a comment.</p>
-  <% end %>
-</div>
+<% unless @episode.old? %>
+  <div class="content add_comment">
+    <% if current_user %>
+      <h3>Add your comment:</h3>
+      <p class="comment_profile">
+        Signed in as <strong><%= link_to current_user.name, current_user %></strong>.
+      </p>
+      <%= render :partial => 'comments/form' %>
+    <% else %>
+      <p>You must <%= link_to "sign in through GitHub", login_path(:return_to => request.url) %> to post a comment.</p>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -15,6 +15,26 @@ describe Episode do
     Episode.unpublished.should_not include(a)
   end
 
+  it "should be marked as old if older than 3 months" do
+    Episode.delete_all
+    a = Factory(:episode, :published_at => 1.year.ago)
+    b = Factory(:episode, :published_at => 4.months.ago)
+    c = Factory(:episode, :published_at => 13.weeks.ago)
+    Episode.all.each do |e|
+      e.old?.should eq(true)
+    end
+  end
+
+  it "should not be marked as old if younger than 3 months" do
+    Episode.delete_all
+    a = Factory(:episode, :published_at => 11.weeks.ago)
+    b = Factory(:episode, :published_at => 2.weeks.ago)
+    c = Factory(:episode, :published_at => 2.weeks.from_now)
+    Episode.all do |e|
+      e.old?.should eq(false)
+    end
+  end
+
   it "should sort recent episodes in descending order" do
     Episode.delete_all
     e1 = Factory(:episode)


### PR DESCRIPTION
- Chaged episodes#show to disable comments if episode was published "too long ago" (added method in model and rspec tests) - this might be helpful to suppress spam comments on older episodes since most discussion goes on directly after publishing. Thus, I chose to set 3 months as a limit for new comments.
- Changed  comments/_comment.html.erb to always show "report as spam" link and not only if no user available - I did this because newer comments cannot be reported anymore on railscasts.com since the authentication system with Github was introduced.
