### PR TITLE
Change in the way to set permalinks

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -169,6 +169,6 @@ class Episode < ActiveRecord::Base
   end
 
   def set_permalink
-    self.permalink = name.downcase.gsub(/[^0-9a-z]+/, ' ').strip.gsub(' ', '-') if name
+    self.permalink = name.parameterize if name
   end
 end


### PR DESCRIPTION
Replaced calls to #gsub by #parameterize introduced in Rails 3.
