### PR TITLE
Explicitly include episode to avoid hitting ActiveRecord's cache so much

### DIFF
--- a/app/views/episodes/_comments.html.erb
+++ b/app/views/episodes/_comments.html.erb
@@ -1,4 +1,4 @@
 <div id="comments">
-  <%= nested_comments @episode.comments.includes(:user).arrange(:order => "created_at asc") %>
+  <%= nested_comments @episode.comments.includes(:user, :episode).arrange(:order => "created_at asc") %>
   <%= render "comments/form" %>
 </div>


### PR DESCRIPTION
Since @episode is loaded by cancan you can't eager load its comments up-front. You do this in the partial, but for some reason whenever you're accessing comment.episode it's hitting ActiveRecord's cache. This fixes it.
