### PR TITLE
CSRF Vulnerability!!!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,14 @@ class ApplicationController < ActionController::Base
     redirect_to root_url, :alert => exception.message
   end
 
+  protected
+
+  # overrides ActionController::RequestForgeryProtection#handle_unverified_request
+  def handle_unverified_request
+    super
+    cookies.delete(:token)
+  end
+
   private
 
   def user_for_paper_trail


### PR DESCRIPTION
Submit any form on the site without a valid CSRF `authenticity_token` and it still works. An easy way to reproduce this is to remove the `authenticity_token` hidden input from a form using your browser's DOM inspector before submitting.

This pull request overrides [handle_unverified_request](https://github.com/rails/rails/blob/7fb99e5743d88c04357e09960d112376428a6faa/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L84) to invalidate `cookies[:token]`.

This same issues affects [Episode 274](http://railscasts.com/episodes/274-remember-me-reset-password) and probably others too, so you may want to update the show notes.

BTW, I'm a huge fan of Railscasts.
