### PR TITLE
Added /comments.rss which shows last created/updated comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,7 +2,10 @@ class CommentsController < ApplicationController
   load_and_authorize_resource
 
   def index
-    @comments = @comments.search(params[:comment_search]).recent.paginate(:page => params[:page], :per_page => 50)
+    respond_to do |format|
+      format.html { @comments = @comments.search(params[:comment_search]).recent.paginate(:page => params[:page], :per_page => 50) }
+      format.rss { @comments = @comments.where('updated_at > ?', 1.week.ago).order('updated_at DESC') }
+    end
   end
 
   def new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,7 @@ class Ability
     can :access, :info
     can :create, :feedback_messages
     can [:read, :create, :login, :unsubscribe], :users
+    can :read, :comments
 
     if user
       can :logout, :users

--- a/app/views/comments/index.rss.builder
+++ b/app/views/comments/index.rss.builder
@@ -1,0 +1,22 @@
+description = "Every week you will be treated to a new RailsCasts episode featuring tips and tricks with Ruby on Rails, the popular web development framework. These screencasts are short and focus on one technique so you can quickly move on to applying it to your own project. The topics are geared toward the intermediate Rails developer, but beginners and experts will get something out of it as well."
+
+xml.rss :version => "2.0" do
+  xml.channel do
+    xml.title "RailsCasts Recent Comments"
+    xml.link 'http://railscasts.com/comments'
+    xml.description "Recent comments to all RailsCasts"
+    xml.language 'en'
+    xml.pubDate @comments.first.updated_at.to_s(:rfc822)
+    xml.lastBuildDate @comments.first.updated_at.to_s(:rfc822)
+
+    @comments.each do |comment|
+      xml.item do
+        xml.title "Comment by #{comment.user.name} on Episode #{comment.episode.full_name}"
+        xml.description comment.content
+        xml.pubDate comment.updated_at.to_s(:rfc822)
+        xml.guid({:isPermaLink => "false"}, "comment-#{comment.id}-#{comment.updated_at.to_i}")
+        xml.link episode_url(comment.episode, :view => "comments", :anchor => "comment_#{comment.id}") 
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -32,11 +32,11 @@ describe "Ability" do
       @ability.should be_able_to(:create, :feedback_messages)
     end
 
-    it "cannot even create comments" do
+    it "can only view comments" do
+      @ability.should be_able_to(:index, :comments)
       @ability.should_not be_able_to(:create, :comments)
       @ability.should_not be_able_to(:update, :comments)
       @ability.should_not be_able_to(:destroy, :comments)
-      @ability.should_not be_able_to(:index, :comments)
     end
   end
 

--- a/spec/requests/comments_request_spec.rb
+++ b/spec/requests/comments_request_spec.rb
@@ -76,4 +76,12 @@ describe "Comments request" do
     page.should_not have_content("Hello world!")
     page.should have_content("Back to the Future")
   end
+
+  it "provides RSS feed of recent comments" do
+    Factory(:comment, :content => "Hello world!")
+    Factory(:comment, :content => "Back to the Future", :site_url => "http://example.com")
+    visit comments_path(:format => :rss)
+    page.should have_content("Hello world!")
+    page.should have_content("Back to the Future")
+  end
 end


### PR DESCRIPTION
/comments is now also public

The RSS version of /comments is slightly different than the HTML version, instead of sorting by created_at and showing the first 50 it sorts by updated_at (so that revised comments can easily be moderated) and it shows all comments created in the last week.
