### PR TITLE
Added button to discard a reply to a comment.

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -72,6 +72,9 @@ puts "code block"
           <% end %>
           <div class="actions">
             <%= f.submit(@comment.new_record? ? "Post Comment" : "Update Comment") %>
+            <% if params[:controller] == "comments" %>
+              <%= link_to "Discard", "#", :class => "remove_comment" %>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -60,5 +60,12 @@ $(function() {
         $(this).children(".clippy_label").text("copied");
       }
     });
+
+    // Remove reply-to-comment field
+    $(".nested_comments").delegate(".remove_comment", "click", function() {
+      $(this).closest("div#new_comment").remove();
+
+      return false;
+    });
   }
 });


### PR DESCRIPTION
Hey!

I've created a button on your New Comment form which is visible only when the form is being used for replying to another comment. The button unobtrusively removes the form from the page (actually removes it from the DOM, it's not just hiding it). It's a small commit, but a feature I think should be available in those cases where you figure you really don't want to reply anyway, when you clicked the wrong reply link or whatever.

Hope you find it useful. :-)
